### PR TITLE
Add title/aria-label to buttons to indicate global vs. faction

### DIFF
--- a/sidebar.js
+++ b/sidebar.js
@@ -263,23 +263,26 @@ class TechSidebar extends React.Component {
         if (node.prereqs && node.prereqs.filter(prereq => prereq !== "").length > 0) {
             let prereqElements = [];
             node.prereqs.filter(prereq => prereq !== "").forEach(prereq => {
+                let tech = this.findTechByName(prereq);
                 prereqElements.push(
                     React.createElement(
                         MaterialUI.Button,
                         {
                             key: prereq,
                             onClick: () => {
-                                this.setState({ node: this.findTechByName(prereq) });
+                                this.setState({ node: tech });
                                 network.selectNodes([prereq]);
                                 network.focus(prereq);
                                 updateLocationHash(prereq);
                             },
                             variant: "contained",
-                            className: "prereqButton" + (this.findTechByName(prereq).researchDone ? " researchDone" : ""),
+                            className: "prereqButton" + (tech.researchDone ? " researchDone" : ""),
                             size: "small",
-                            color: this.findTechByName(prereq).isProject ? "success" : "primary"
+                            title: tech.isProject ? "Faction Project" : "Global Research",
+                            'aria-label': tech ? (tech.friendlyName + " "  + (tech.isProject ? "Faction Project" : "Global Research")) : "",
+                            color: tech.isProject ? "success" : "primary"
                         },
-                        this.findTechByName(prereq) ? this.findTechByName(prereq).friendlyName : ""
+                        tech ? tech.friendlyName : ""
                     )
                 );
             });
@@ -299,9 +302,10 @@ class TechSidebar extends React.Component {
         }
 
         let blockingText, blockingList;
-        if (this.findBlockingTechs(node).length > 0) {
+        let blockingTechs = this.findBlockingTechs(node);
+        if (blockingTechs.length > 0) {
             let blockerElements = [];
-            this.findBlockingTechs(node).forEach(blocked => {
+            blockingTechs.forEach(blocked => {
                 blockerElements.push(
                     React.createElement(
                         MaterialUI.Button,
@@ -318,6 +322,8 @@ class TechSidebar extends React.Component {
                             variant: "contained",
                             className: "prereqButton",
                             size: "small",
+                            title: blocked.isProject ? "Faction Project" : "Global Research",
+                            'aria-label': blocked ? (blocked.friendlyName + " "  + (blocked.isProject ? "Faction Project" : "Global Research")) : "",
                             color: blocked.isProject ? "success" : "primary"
                         },
                         blocked.friendlyName


### PR DESCRIPTION
`aria-label` will be used by screen readers - example with Windows Narrator: https://user-images.githubusercontent.com/10624856/197345931-d73a5e03-8e40-451c-b8a0-59c1f97598d9.mp4

I thought I'd also add `title` so someone who can't distinguish between blue and green would have the info too, but Windows Narrator didn't use that, hence adding `aria-label` as well.